### PR TITLE
Aotnew

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;;Go to marathon.core to update +version+ as well!
-(defproject marathon "4.2.16-SNAPSHOT"
+(defproject marathon "4.2.17-SNAPSHOT"
   :description "An Integrated Suite of Rotational Analysis Tools."
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [spork "0.2.1.8-SNAPSHOT"
@@ -25,7 +25,8 @@
              :large {:jvm-opts ^:replace ["-Xmx700g" "-Xms100g"
                                           #_#_"-XX:NewSize=100g"
                                           "-XX:TLABSize=500m"]
-                     :source-paths ["src" "../spork/src/"]}}
+                     :source-paths ["src" "../spork/src/"]}
+             :aot {:aot [marathon.analysis.random]}}
   :plugins [[reifyhealth/lein-git-down "0.4.1"]]
   :middleware [lein-git-down.plugin/inject-properties]
   :repositories [["public-github" {:url "git://github.com"}]]

--- a/src/marathon/core.clj
+++ b/src/marathon/core.clj
@@ -18,7 +18,7 @@
             [proc [demandanalysis :as da]])
   (:use    [marathon.project] [clojure.repl]))
 
-(def +version+ "4.2.16-SNAPSHOT")
+(def +version+ "4.2.17-SNAPSHOT")
 
 (def noisy (atom true))
 (defn toggle-noisy [] (swap! noisy (fn [n] (not n))))


### PR DESCRIPTION
Eliminates sneaky bug that seemingly successfully AOT compiled m4, even allowing a gui to launch, but with silent unbound vars only present at runtime.  Problem was due to naive or crack-headed macro abuse that implemented policy templates overly complicated and had stuff happening at macroexpansion time as a side effect, instead of emitting code.